### PR TITLE
fix tests

### DIFF
--- a/geo_test.go
+++ b/geo_test.go
@@ -1,6 +1,7 @@
 package geo
 
 import (
+	"fmt"
 	"net"
 	"os"
 	"testing"
@@ -14,9 +15,11 @@ func TestLookupCountry(t *testing.T) {
 	if licenseKey == "" {
 		t.Skip("require envvar MAXMIND_LICENSE_KEY")
 	}
+	dbURL := fmt.Sprintf("https://download.maxmind.com/app/geoip_download?license_key=%s&edition_id=GeoLite2-Country&suffix=tar.gz", licenseKey)
+
 	filePath := "GeoLite2-Country.mmdb"
 	defer os.Remove(filePath)
-	l := New(licenseKey, time.Hour, filePath)
+	l := New(dbURL, time.Hour, filePath)
 	time.Sleep(20 * time.Second) // wait long enough to load database remotely
 	_, err := os.Stat(filePath)
 	assert.NoError(t, err, "should have cached the database locally")
@@ -27,11 +30,14 @@ func TestLookupCountry(t *testing.T) {
 	doTestLookup(t, l, "45.55.177.174", "US")
 	doTestLookup(t, l, "139.59.59.44", "IN")
 	doTestLookup(t, l, "188.166.36.215", "NL")
+	doTestLookup(t, l, "217.164.123.118", "AE")
+	doTestLookup(t, l, "87.107.251.220", "IR")
+	doTestLookup(t, l, "120.216.165.160", "CN")
 	doTestLookup(t, l, "adsfs423afsd234:2343", "")
 	doTestLookup(t, l, "adsfs423afsd234:2343", "")
 
 	// Make sure that when the local file exists, lookup works immediately.
-	l2 := New(licenseKey, time.Hour, filePath)
+	l2 := New(dbURL, time.Hour, filePath)
 	time.Sleep(100 * time.Millisecond)
 	doTestLookup(t, l2, "188.166.36.215", "NL")
 }


### PR DESCRIPTION
They were introduced when extracting the code out of `http-proxy-lantern`. Merging as it only affects tests.